### PR TITLE
"better" error handling

### DIFF
--- a/lib/thrift_client.rb
+++ b/lib/thrift_client.rb
@@ -5,6 +5,7 @@ require 'thrift_client/abstract_thrift_client'
 
 class ThriftClient < AbstractThriftClient
   class NoServersAvailable < StandardError; end
+  class TransportError < StandardError; end
 
 =begin rdoc
 Create a new ThriftClient instance. Accepts an internal Thrift client class (such as CassandraRb::Client), a list of servers with ports, and optional parameters.

--- a/lib/thrift_client/abstract_thrift_client.rb
+++ b/lib/thrift_client/abstract_thrift_client.rb
@@ -226,7 +226,8 @@ class AbstractThriftClient
       #this is OK because we intend to immediately re-raise an exception
     end
     if errors.any?
-      raise ThriftClient::TransportError, "No live servers in #{@server_list.inspect}."
+      raise ThriftClient::TransportError, errors[0] unless errors.count > 1
+      raise ThriftClient::TransportError, errors.inspect
     end
     raise ThriftClient::NoServersAvailable, "No live servers in #{@server_list.inspect}."
   end

--- a/lib/thrift_client/abstract_thrift_client.rb
+++ b/lib/thrift_client/abstract_thrift_client.rb
@@ -220,7 +220,7 @@ class AbstractThriftClient
     begin
       @server_list.collect { |srv|
         error_msg = srv.connection.transport.instance_variable_get(:@rbuf).force_encoding("ASCII-8BIT").gsub("\f", ' ').scan(/[[:print:]]/).join
-        errors << "Error on server #{srv} : #{error_msg}"
+        errors << "Error on server #{srv} : #{error_msg}" unless error_msg.blank?
       }
     rescue
       #this is OK because we intend to immediately re-raise an exception

--- a/lib/thrift_client/abstract_thrift_client.rb
+++ b/lib/thrift_client/abstract_thrift_client.rb
@@ -216,6 +216,18 @@ class AbstractThriftClient
   end
 
   def no_servers_available!
+    errors = []
+    begin
+      @server_list.collect { |srv|
+        error_msg = srv.connection.transport.instance_variable_get(:@rbuf).force_encoding("ASCII-8BIT").gsub("\f", ' ').scan(/[[:print:]]/).join
+        errors << "Error on server #{srv} : #{error_msg}"
+      }
+    rescue
+      #this is OK because we intend to immediately re-raise an exception
+    end
+    if errors.any?
+      raise ThriftClient::TransportError, "No live servers in #{@server_list.inspect}."
+    end
     raise ThriftClient::NoServersAvailable, "No live servers in #{@server_list.inspect}."
   end
 end


### PR DESCRIPTION
@mswain is this crazy ? really don't like reaching into .transport ivars but errors will come out looking like this:

```
=> #<ThriftClient::TransportError: Error on server 127.0.0.1:9160 : multiget_slice column name must not be empty>
```

instead of:

```
=> #<ThriftClient::TransportError: No live servers in [#<ThriftHelpers::Server:0x007fe1f155f9d0 @connection_string="127.0.0.1:9160", @client_class=CassandraThrift::Cassandra::Client, @options={:protocol=>Thrift::BinaryProtocolAccelerated, :protocol_extra_params=>[], :transport=>Thrift::Socket, :transport_wrapper=>Thrift::FramedTransport, :raise=>true, :defaults=>{}, :exception_classes=>[IOError, Thrift::Exception, Thrift::ApplicationException, Thrift::TransportException], :exception_class_overrides=>[], :retries=>3, :server_retry_period=>1, :server_max_requests=>nil, :retry_overrides=>{}, :wrapped_exception_classes=>[Thrift::ApplicationException, Thrift::TransportException], :connect_timeout=>1, :timeout=>10, :timeout_overrides=>{}, :cached_connections=>false, :thrift_client_class=>ThriftClient}, @cached=false, @marked_down_til=2013-11-16 17:24:43 +0000, @connection=#<ThriftHelpers::Connection::Socket:0x007fe1f1a632b0 @transport=#<Thrift::FramedTransport:0x007fe1f1a62ec8 @transport=#<Thrift::Socket:0x007fe1f1a62fe0 @host="127.0.0.1", @port=9160, @timeout=10, @desc="127.0.0.1:9160", @handle=nil>, @rbuf="\x80\x01\x00\x02\x00\x00\x00\x0Emultiget_slice\x00\x00\x00\x00\f\x00\x01\v\x00\x01\x00\x00\x00\x1Dcolumn name must not be empty\x00\x00", @wbuf="", @read=true, @write=true, @index=67>, @transport_wrapper=Thrift::FramedTransport, @server="127.0.0.1:9160", @timeout=1>, @client=nil>].>
```
